### PR TITLE
Ignore __pycache__ and .pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 ./venv/*
+
+# Python cache files
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
Updated `.gitignore` to exclude `__pycache__` as well as `.pyc` `.pyo` `.pyd` files